### PR TITLE
Added support for Fabric API's armor renderer

### DIFF
--- a/src/main/java/furgl/hideArmor/mixin/RenderArmorMixin.java
+++ b/src/main/java/furgl/hideArmor/mixin/RenderArmorMixin.java
@@ -13,7 +13,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 
-@Mixin(ArmorFeatureRenderer.class)
+@Mixin(value = ArmorFeatureRenderer.class, priority = 999)
 public abstract class RenderArmorMixin<T extends LivingEntity, M extends BipedEntityModel<T>, A extends BipedEntityModel<T>> {
 
 	@Inject(method = "renderArmor", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
### Changes

- Added `priority = 999` to mixin `RenderArmorMixin`.

### Purpose

Add support to Fabric API's armor renderer. By setting the priority to less than 1000 (the default value that is used by Fabric API's own mixin, [`ArmorFeatureRendererMixin.java`](https://github.com/FabricMC/fabric/blob/5f243a8b7849eac4b30cd876a22a127797a1c406/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/mixin/client/rendering/ArmorFeatureRendererMixin.java#L37), Hide-Armor's visibility toggle code is run first i.e. has *priority*.

### Rationale

Fabric API's [`fabric-rendering-v1`](https://github.com/FabricMC/fabric/tree/1.19.2/fabric-rendering-v1) includes an interface for mods to add more specialised/dynamic armor and armor features - see [`ArmorRenderer.java`](https://github.com/FabricMC/fabric/blob/1.19.2/fabric-rendering-v1/src/client/java/net/fabricmc/fabric/api/client/rendering/v1/ArmorRenderer.java). Being part of Fabric API, many mods utilise this feature; namely, [RelicEx](https://github.com/CleverNucleus/RelicEx) and its embedded library [ArmorRenderLib](https://github.com/CleverNucleus/ArmorRenderLib).

I was made aware of this through an issue made to one of my mods - see [here](https://github.com/CleverNucleus/RelicEx/issues/15). Of course, my mod uses the aforementioned Fabric API's rendering interface, hence this merge request.

I hope this is okay,
Thanks.

